### PR TITLE
add Maven project configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.br.senai.ads3</groupId>
+    <artifactId>Agenda_Fatesg</artifactId>
+    <version>1.0.1</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <exec.mainClass>com.br.senai.ads3.agenda_fatesg.Agenda_Fatesg</exec.mainClass>
+    </properties>    
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit</groupId>
+            <artifactId>junit5-api</artifactId>
+            <version>5.0.0-ALPHA</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.antublue</groupId>
+            <artifactId>test-engine</artifactId>
+            <version>6.0.0-M2</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
+    <build>
+    <plugins>
+        <!-- Plugin de Compilação: ONDE O LOMBOK DEVE FICAR -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.13.0</version>
+            <configuration>
+                <release>21</release>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.38</version>
+                    </path>
+                </annotationProcessorPaths>
+               <compilerArgs>
+                  <arg>-Xlint</arg>
+               </compilerArgs>
+            </configuration>
+        </plugin>
+
+        <!-- Plugin do JAR: APENAS PARA O MANIFESTO -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.4.1</version>
+            <configuration>
+                <archive>
+                    <manifest>
+                        <addClasspath>true</addClasspath>
+                        <mainClass>com.br.senai.ads3.agenda_fatesg.pages.Form_Listagem</mainClass>
+                    </manifest>
+                </archive>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+</project>


### PR DESCRIPTION
Adicionado o arquivo pom.xml com a configuração inicial do projeto Maven. Inclui dependências do Lombok (com annotation processor configurado), JUnit 5 e test-engine para testes, além dos plugins de compilação (Java 21) e geração do JAR executável com manifest apontando para a classe Form_Listagem.